### PR TITLE
refactor(header): change max-length to a warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,14 @@
 module.exports = {
-  rules: {
-    'body-leading-blank': [1, 'always'],
-    'footer-leading-blank': [1, 'always'],
-    'header-max-length': [2, 'always', 72],
-    'scope-case': [2, 'always', 'lowerCase'],
-    'signed-off-by': [1, 'always', 'Signed-off-by:'],
-    'subject-empty': [2, 'never'],
-    'subject-full-stop': [2, 'never', '.'],
-    'type-case': [2, 'always', 'lowerCase'],
-    'type-empty': [2, 'never'],
-    'type-enum': [2, 'always', ['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test']],
-  },
+    rules: {
+        'body-leading-blank': [ 1, 'always' ],
+        'footer-leading-blank': [ 1, 'always' ],
+        'header-max-length': [ 1, 'always', 72 ],
+        'scope-case': [ 2, 'always', 'lowerCase' ],
+        'signed-off-by': [ 1, 'always', 'Signed-off-by:' ],
+        'subject-empty': [ 2, 'never' ],
+        'subject-full-stop': [ 2, 'never', '.' ],
+        'type-case': [ 2, 'always', 'lowerCase' ],
+        'type-empty': [ 2, 'never' ],
+        'type-enum': [ 2, 'always', [ 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test' ] ]
+    }
 };

--- a/tests/unit/index.spec.js
+++ b/tests/unit/index.spec.js
@@ -58,9 +58,9 @@ describe('@dwp/commitlint-config-base', () => {
       describe('header-max-length', () => {
         const rule = commitlintConfig.rules['header-max-length'];
 
-        it('should be an error', () => {
-          expect(rule[0]).toEqual(2);
-        });
+                it('should be an warning', () => {
+                    expect(rule[0]).toEqual(1);
+                });
 
         it('should be enabled', () => {
           expect(rule[1]).toEqual('always');


### PR DESCRIPTION
change the header-max-length to a warning for that rare occasion that it
can't be truncated below 72